### PR TITLE
feat: add session memory module for consistent entity translation

### DIFF
--- a/data_model.py
+++ b/data_model.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import Literal
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class Translation(BaseModel):
@@ -22,6 +22,17 @@ class CharacterEntry(BaseModel):
     translated_name: str
     gender: Literal["male", "female", "unknown"]
     notes: str = ""
+
+    @field_validator("gender", mode="before")
+    @classmethod
+    def coerce_gender(cls, v: object) -> str:
+        if isinstance(v, str):
+            v_lower = v.lower().strip()
+            if v_lower in ("male", "m", "man", "boy"):
+                return "male"
+            if v_lower in ("female", "f", "woman", "girl", "woman"):
+                return "female"
+        return "unknown"
 
 
 class SessionMemory(BaseModel):

--- a/data_model.py
+++ b/data_model.py
@@ -1,7 +1,30 @@
+from enum import Enum
 from pydantic import BaseModel
 
 
 class Translation(BaseModel):
     input_text: str
-    translated_texts: list[str]
-    notes: str | None
+    translated_text: str
+
+class BubbleType(str, Enum):
+    FREE = "free"
+    FIXED = "fixed"
+
+
+class EntityEntry(BaseModel):
+    original: str
+    translated: str
+
+
+class CharacterEntry(BaseModel):
+    original_name: str
+    translated_name: str
+    gender: str   # "male" | "female" | "unknown"
+    notes: str = ""
+
+
+class SessionMemory(BaseModel):
+    characters: list[CharacterEntry] = []
+    places: list[EntityEntry] = []
+    organizations: list[EntityEntry] = []
+    story_summary: str = ""

--- a/data_model.py
+++ b/data_model.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 from pydantic import BaseModel
 
 
@@ -19,7 +20,7 @@ class EntityEntry(BaseModel):
 class CharacterEntry(BaseModel):
     original_name: str
     translated_name: str
-    gender: str   # "male" | "female" | "unknown"
+    gender: Literal["male", "female", "unknown"]
     notes: str = ""
 
 

--- a/docs/superpowers/specs/2026-04-12-memory-module-design.md
+++ b/docs/superpowers/specs/2026-04-12-memory-module-design.md
@@ -1,0 +1,142 @@
+# Memory Module Design
+
+**Date:** 2026-04-12  
+**Status:** Approved
+
+## Overview
+
+Add a session-scoped memory module to manga-polyglot that tracks named entities (characters, places, organizations), character gender, and a rolling story summary across all pages in a translation run. This enables consistent entity translations and correct pronoun usage throughout a session.
+
+---
+
+## Goals
+
+- Consistent translation of character names, place names, and organization names across pages
+- Correct pronoun usage via tracked character gender
+- Rolling story summary injected as context to improve translation quality for later pages
+- Human-readable memory file for debugging and inspection
+
+---
+
+## Data Model (`data_model.py`)
+
+Two new Pydantic models:
+
+```python
+class CharacterEntry(BaseModel):
+    original_name: str       # name as it appears in source (e.g. 田中)
+    translated_name: str     # established translation (e.g. Tanaka)
+    gender: str              # "male" | "female" | "unknown"
+    notes: str = ""          # optional: role, speech register, etc.
+
+class SessionMemory(BaseModel):
+    characters: list[CharacterEntry] = []
+    places: list[EntityEntry] = []
+    organizations: list[EntityEntry] = []
+    story_summary: str = ""         # rolling summary, ~150 words max
+```
+
+---
+
+## Persistence
+
+- **Format:** Markdown file at `{temp_dir}/memory.md`
+- **On session start:** `driver()` checks for `{temp_dir}/memory.md`. If present, loads it into a `SessionMemory` instance (supports resuming interrupted runs). If absent, starts with an empty `SessionMemory`.
+- **After each page:** The updated `SessionMemory` is serialized back to `{temp_dir}/memory.md`.
+
+### Markdown format
+
+```markdown
+# Session Memory
+
+## Story Summary
+<rolling summary text>
+
+## Characters
+| Original | Translated | Gender | Notes |
+|----------|------------|--------|-------|
+| 田中 | Tanaka | male | protagonist |
+
+## Places
+| Original | Translated |
+|----------|------------|
+| 新宿 | Shinjuku |
+
+## Organizations
+| Original | Translated |
+|----------|------------|
+| 黒烏 | Black Crow Corp |
+```
+
+---
+
+## Memory Update Flow (`text_utils.py`)
+
+New function: `update_session_memory(translations, session_memory, model, temp_dir) -> SessionMemory`
+
+**Called in `driver()` once per page**, after the translation loop for that page completes:
+
+```python
+session_memory = update_session_memory(translations, session_memory, llm_name, temp_dir)
+```
+
+**Inputs:**
+- `translations`: list of `{"original": str, "translated": str}` pairs from the current page
+- `session_memory`: current `SessionMemory` state
+- `model`: LLM model name (same as used for translation)
+- `temp_dir`: path for writing `memory.md`
+
+**Behaviour:**
+- Builds a prompt containing the current page's translations and the current memory state
+- Calls the LLM using `SessionMemory.model_json_schema()` as the structured output format
+- LLM is instructed to:
+  - Identify new named entities (characters with gender, places, organizations)
+  - Update existing entries if the LLM finds a better/corrected form
+  - Produce a revised rolling story summary (max ~150 words)
+- Returns the updated `SessionMemory`
+- Serializes to `{temp_dir}/memory.md`
+
+---
+
+## Prompt Injection (`text_utils.py`)
+
+`get_formatted_user_prompt()` and `get_formatted_user_prompt_with_image()` receive a new optional parameter:
+
+```python
+session_memory: SessionMemory = None
+```
+
+If `session_memory` is non-empty, a section is injected between the context block and the previous-translations block:
+
+```
+Known entities (use these translations consistently):
+- Characters: Tanaka (male), Sakura (female, childhood friend)
+- Places: Shinjuku, Black Crow HQ
+- Organizations: Black Crow Corp
+
+Story so far: <rolling summary>
+```
+
+**Prompt section order:**
+1. Page context (lookback + current + lookahead)
+2. Session memory (entities + story summary) ← new
+3. Previous translations on this page
+4. Text to translate + output instructions
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `data_model.py` | Add `CharacterEntry`, `SessionMemory` models |
+| `text_utils.py` | Add `update_session_memory()`, inject memory into prompt functions |
+| `inference.py` | Load/pass `SessionMemory` in `driver()`, call `update_session_memory()` after each page |
+
+---
+
+## Out of Scope
+
+- Persisting memory across different manga series or separate runs (beyond resume support)
+- A UI or manual editor for the memory file
+- Automatic gender correction based on downstream context

--- a/inference.py
+++ b/inference.py
@@ -133,6 +133,8 @@ def driver(input_dir, temp_dir, output_dir, config, source_language, target_lang
     llm_name = config["llm_name"]
     font_path = config["font_path"]
     image_enabled = config.get("image_enabled", False)
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir, exist_ok=True)
     memory_path = os.path.join(temp_dir, "memory.md")
     session_memory = load_memory(memory_path)
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -151,9 +153,6 @@ def driver(input_dir, temp_dir, output_dir, config, source_language, target_lang
         .eval()
     )
     processor = AutoProcessor.from_pretrained(ocr_model_id)
-
-    if not os.path.exists(temp_dir):
-        os.mkdir(temp_dir)
 
     img_paths = sorted(os.listdir(input_dir))
     computed = {}
@@ -256,9 +255,10 @@ def driver(input_dir, temp_dir, output_dir, config, source_language, target_lang
                 {"original": text, "translated": translated, "polygon": text_box}
             )
 
-        session_memory = update_session_memory(
-            translations, session_memory, llm_name, temp_dir
-        )
+        if translations:
+            session_memory = update_session_memory(
+                translations, session_memory, llm_name, temp_dir
+            )
 
         translated_image = replace_text_with_translation(
             cleaned_file_path, font_path, translations

--- a/inference.py
+++ b/inference.py
@@ -1,44 +1,99 @@
 import os
 import gc
-import time
+import cv2
 import json
 import torch
 import argparse
+import numpy as np
 from PIL import Image
 from tqdm import tqdm
-from collections import deque
 from img_utils import (
+    imread,
     replace_text_with_translation,
     fill_bubble_with_estimated_color,
     get_text_insertion_boxes,
 )
+from transformers import Sam3Processor, Sam3Model
 from transformers import RTDetrV2ForObjectDetection, RTDetrImageProcessor
 from transformers import AutoProcessor, AutoModelForImageTextToText
 from text_detection import detect_text
 
-from text_utils import translate
+from text_utils import translate, update_session_memory
+from data_model import BubbleType, SessionMemory
+from memory_utils import load_memory
 
 
-def clean_page(img_path, temp_dir, boxes):
+
+def clean_text_blocks(img, mask):
+    _, mask = cv2.threshold(mask, 127, 255, cv2.THRESH_BINARY)
+    inpainted_telea = cv2.inpaint(img, mask, inpaintRadius=5, flags=cv2.INPAINT_TELEA)
+    return inpainted_telea
+
+
+def clean_bubble_free_text(pil_image, box, masked_block):
+    
+    numpy_image = np.array(pil_image)
+    img = cv2.cvtColor(numpy_image, cv2.COLOR_RGB2BGR)
+
+    masked_block = masked_block.cpu().numpy()
+
+    masked_block = (masked_block * 255).astype(np.uint8)
+    
+    x1, y1, x2, y2 = list(map(int, box))
+    cropped_img = img[y1:y2, x1:x2]
+    cleaned_block = clean_text_blocks(cropped_img, masked_block)
+    filtered_block = cv2.medianBlur(cleaned_block, 25)
+    img[y1:y2, x1:x2] = filtered_block
+
+    color_converted_image = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    pil_image = Image.fromarray(color_converted_image)
+    return pil_image
+
+def create_masks(pil_image, box: dict, segmentation_model, segmentation_processor):
+    box = box["original_text_box"]
+    box = list(map(int, box))
+
+    cropped_image = pil_image.crop(box)
+    inputs = segmentation_processor(images=cropped_image, text="manga dialogue letters", return_tensors="pt").to(segmentation_model.device)
+
+    with torch.no_grad():
+        outputs = segmentation_model(**inputs)
+
+    # Post-process results
+    results = segmentation_processor.post_process_instance_segmentation(
+        outputs,
+        threshold=0.5,
+        mask_threshold=0.5,
+        target_sizes=inputs.get("original_sizes").tolist()
+    )[0]
+
+    return results['masks']
+
+def clean_page(img_path: str, temp_dir: str, boxes: list[dict], segmentation_model, segmentation_processor):
     pil_image = Image.open(img_path).convert("RGB")
     file_name = os.path.basename(img_path)
     cleaned_file_path = os.path.join(temp_dir, file_name)
     for box in boxes:
-        pil_image = fill_bubble_with_estimated_color(
-            pil_image, box["original_text_box"]
-        )
+        if box["type"] == BubbleType.FIXED:
+            pil_image = fill_bubble_with_estimated_color(
+                pil_image, box["original_text_box"]
+            )
+        elif box["type"] == BubbleType.FREE:
+            masks = create_masks(pil_image, box, segmentation_model, segmentation_processor)
+            for mask in masks:
+                pil_image = clean_bubble_free_text(pil_image, box["original_text_box"], mask)
 
     pil_image.save(cleaned_file_path)
     return cleaned_file_path
 
 
-def extract_text(img_path, boxes, model, processor):
+def extract_text(img_path: str, boxes: list[dict], model, processor):
     max_pixels = 1280 * 28 * 28
     texts = []
     text_boxes = []
+    img = Image.open(img_path)
     for box in boxes:
         box = box["insertion_polygon"]
-        img = Image.open(img_path)
         cropped_img = img.crop(box)
         cropped_img = cropped_img.convert("L").convert("RGB")
         messages = [
@@ -73,12 +128,17 @@ def extract_text(img_path, boxes, model, processor):
 
 
 def driver(input_dir, temp_dir, output_dir, config, source_language, target_language):
-    context_pages = 3
     ocr_model_id = config["ocr_model"]
     model_id = config["text_detection_model_path"]
     llm_name = config["llm_name"]
     font_path = config["font_path"]
+    image_enabled = config.get("image_enabled", False)
+    memory_path = os.path.join(temp_dir, "memory.md")
+    session_memory = load_memory(memory_path)
     device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    segmentation_model = Sam3Model.from_pretrained("jetjodh/sam3").to(device)
+    segmentation_processor = Sam3Processor.from_pretrained("jetjodh/sam3")
 
     image_processor = RTDetrImageProcessor.from_pretrained(model_id)
     det_model = RTDetrV2ForObjectDetection.from_pretrained(model_id)
@@ -107,7 +167,7 @@ def driver(input_dir, temp_dir, output_dir, config, source_language, target_lang
         boxes = get_text_insertion_boxes(results, expand_ratio=0.8)
 
         ## clean the image to remove the texts
-        cleaned_file_path = clean_page(img_path, temp_dir, boxes)
+        cleaned_file_path = clean_page(img_path, temp_dir, boxes, segmentation_model, segmentation_processor)
 
         # Extract texts from the bounding boxes
         texts, text_boxes = extract_text(img_path, boxes, ocr_model, processor)
@@ -121,15 +181,16 @@ def driver(input_dir, temp_dir, output_dir, config, source_language, target_lang
 
     del ocr_model
     del det_model
-    torch.cuda.empty_cache()
+    del segmentation_model
     gc.collect()
-    time.sleep(5)
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
 
     lookback_pages = 2
     lookahead_pages = 2
     n_pages = len(img_paths)
 
-    context_list = deque(maxlen=context_pages)
     for i, img_name in enumerate(tqdm(img_paths)):
 
         img_path = os.path.join(input_dir, img_name)
@@ -140,8 +201,6 @@ def driver(input_dir, temp_dir, output_dir, config, source_language, target_lang
         translations = []
         precomputed_vals = computed[img_path]
         cleaned_file_path = computed[img_path]["clean_img_path"]
-        context_list.append(computed[img_path]["page_context"])
-        context = "\n".join(context_list)
 
         # Build context: lookback + current (optional) + lookahead
         context_parts = []
@@ -168,16 +227,38 @@ def driver(input_dir, temp_dir, output_dir, config, source_language, target_lang
         for text, text_box in zip(
             precomputed_vals["texts"], precomputed_vals["text_boxes"]
         ):
+            # Optionally crop and pass image to the translation model
+            image = None
+            if image_enabled:
+                img = Image.open(img_path)
+                image = img.crop(text_box)
+
+            # Build previous translations for consistency
+            previous_translations = []
+            if translations:
+                for prev in translations:
+                    previous_translations.append({
+                        "original": prev["original"],
+                        "translated": prev["translated"]
+                    })
+
             translated = translate(
                 text,
                 llm_name,
                 context=context,
                 source_language=source_language,
                 target_language=target_language,
+                image=image,
+                previous_translations=previous_translations,
+                session_memory=session_memory,
             )
             translations.append(
                 {"original": text, "translated": translated, "polygon": text_box}
             )
+
+        session_memory = update_session_memory(
+            translations, session_memory, llm_name, temp_dir
+        )
 
         translated_image = replace_text_with_translation(
             cleaned_file_path, font_path, translations
@@ -199,7 +280,7 @@ def main():
         "--source-lang",
         type=str,
         help="the directory to which translated images are stored",
-        default="English",
+        default="Japanese",
     )
 
     parser.add_argument(

--- a/memory_utils.py
+++ b/memory_utils.py
@@ -1,0 +1,105 @@
+import os
+import re
+from data_model import CharacterEntry, EntityEntry, SessionMemory
+
+
+def serialize_memory(memory: SessionMemory, path: str) -> None:
+    lines = ["# Session Memory", ""]
+    lines.append("## Story Summary")
+    lines.append(memory.story_summary or "")
+    lines.append("")
+    lines.append("## Characters")
+    lines.append("| Original | Translated | Gender | Notes |")
+    lines.append("|----------|------------|--------|-------|")
+    for char in memory.characters:
+        lines.append(f"| {char.original_name} | {char.translated_name} | {char.gender} | {char.notes} |")
+    lines.append("")
+    lines.append("## Places")
+    lines.append("| Original | Translated |")
+    lines.append("|----------|------------|")
+    for place in memory.places:
+        lines.append(f"| {place.original} | {place.translated} |")
+    lines.append("")
+    lines.append("## Organizations")
+    lines.append("| Original | Translated |")
+    lines.append("|----------|------------|")
+    for org in memory.organizations:
+        lines.append(f"| {org.original} | {org.translated} |")
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def load_memory(path: str) -> SessionMemory:
+    if not os.path.exists(path):
+        return SessionMemory()
+
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    memory = SessionMemory()
+    sections = re.split(r'\n## ', content)
+
+    for section in sections:
+        header, _, body = section.partition('\n')
+        header = header.lstrip('# ').strip()
+
+        if header == "Story Summary":
+            memory.story_summary = body.strip()
+
+        elif header == "Characters":
+            for row in _parse_table_rows(body):
+                if len(row) >= 4:
+                    memory.characters.append(CharacterEntry(
+                        original_name=row[0],
+                        translated_name=row[1],
+                        gender=row[2],
+                        notes=row[3],
+                    ))
+
+        elif header == "Places":
+            for row in _parse_table_rows(body):
+                if len(row) >= 2:
+                    memory.places.append(EntityEntry(original=row[0], translated=row[1]))
+
+        elif header == "Organizations":
+            for row in _parse_table_rows(body):
+                if len(row) >= 2:
+                    memory.organizations.append(EntityEntry(original=row[0], translated=row[1]))
+
+    return memory
+
+
+def _parse_table_rows(text: str) -> list[list[str]]:
+    rows = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith('|') and not re.match(r'^\|[-| ]+\|$', line):
+            cols = [c.strip() for c in line.strip('|').split('|')]
+            rows.append(cols)
+    return rows[1:]  # skip header row
+
+
+def format_memory_for_prompt(memory: SessionMemory) -> str:
+    if not any([memory.characters, memory.places, memory.organizations, memory.story_summary]):
+        return ""
+
+    parts = ["Known entities (use these translations consistently):"]
+
+    if memory.characters:
+        char_list = ", ".join(
+            f"{c.translated_name} ({c.gender}{', ' + c.notes if c.notes else ''})"
+            for c in memory.characters
+        )
+        parts.append(f"- Characters: {char_list}")
+
+    if memory.places:
+        parts.append(f"- Places: {', '.join(p.translated for p in memory.places)}")
+
+    if memory.organizations:
+        parts.append(f"- Organizations: {', '.join(o.translated for o in memory.organizations)}")
+
+    if memory.story_summary:
+        parts.append(f"\nStory so far: {memory.story_summary}")
+
+    return "\n".join(parts)

--- a/memory_utils.py
+++ b/memory_utils.py
@@ -3,6 +3,10 @@ import re
 from data_model import CharacterEntry, EntityEntry, SessionMemory
 
 
+def _escape_cell(value: str) -> str:
+    return value.replace("|", "&#124;")
+
+
 def serialize_memory(memory: SessionMemory, path: str) -> None:
     lines = ["# Session Memory", ""]
     lines.append("## Story Summary")
@@ -12,19 +16,19 @@ def serialize_memory(memory: SessionMemory, path: str) -> None:
     lines.append("| Original | Translated | Gender | Notes |")
     lines.append("|----------|------------|--------|-------|")
     for char in memory.characters:
-        lines.append(f"| {char.original_name} | {char.translated_name} | {char.gender} | {char.notes} |")
+        lines.append(f"| {_escape_cell(char.original_name)} | {_escape_cell(char.translated_name)} | {char.gender} | {_escape_cell(char.notes)} |")
     lines.append("")
     lines.append("## Places")
     lines.append("| Original | Translated |")
     lines.append("|----------|------------|")
     for place in memory.places:
-        lines.append(f"| {place.original} | {place.translated} |")
+        lines.append(f"| {_escape_cell(place.original)} | {_escape_cell(place.translated)} |")
     lines.append("")
     lines.append("## Organizations")
     lines.append("| Original | Translated |")
     lines.append("|----------|------------|")
     for org in memory.organizations:
-        lines.append(f"| {org.original} | {org.translated} |")
+        lines.append(f"| {_escape_cell(org.original)} | {_escape_cell(org.translated)} |")
 
     with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
@@ -51,55 +55,62 @@ def load_memory(path: str) -> SessionMemory:
             for row in _parse_table_rows(body):
                 if len(row) >= 4:
                     memory.characters.append(CharacterEntry(
-                        original_name=row[0],
-                        translated_name=row[1],
+                        original_name=_unescape_cell(row[0]),
+                        translated_name=_unescape_cell(row[1]),
                         gender=row[2],
-                        notes=row[3],
+                        notes=_unescape_cell(row[3]),
                     ))
 
         elif header == "Places":
             for row in _parse_table_rows(body):
                 if len(row) >= 2:
-                    memory.places.append(EntityEntry(original=row[0], translated=row[1]))
+                    memory.places.append(EntityEntry(original=_unescape_cell(row[0]), translated=_unescape_cell(row[1])))
 
         elif header == "Organizations":
             for row in _parse_table_rows(body):
                 if len(row) >= 2:
-                    memory.organizations.append(EntityEntry(original=row[0], translated=row[1]))
+                    memory.organizations.append(EntityEntry(original=_unescape_cell(row[0]), translated=_unescape_cell(row[1])))
 
     return memory
+
+
+def _unescape_cell(value: str) -> str:
+    return value.replace("&#124;", "|")
 
 
 def _parse_table_rows(text: str) -> list[list[str]]:
     rows = []
     for line in text.splitlines():
         line = line.strip()
-        if line.startswith('|') and not re.match(r'^\|[-| ]+\|$', line):
+        if line.startswith('|') and not re.match(r'^\|[-|: ]+\|$', line):
             cols = [c.strip() for c in line.strip('|').split('|')]
             rows.append(cols)
     return rows[1:]  # skip header row
 
 
 def format_memory_for_prompt(memory: SessionMemory) -> str:
-    if not any([memory.characters, memory.places, memory.organizations, memory.story_summary]):
+    has_entities = any([memory.characters, memory.places, memory.organizations])
+    if not has_entities and not memory.story_summary:
         return ""
 
-    parts = ["Known entities (use these translations consistently):"]
+    parts = []
 
-    if memory.characters:
-        char_list = ", ".join(
-            f"{c.translated_name} ({c.gender}{', ' + c.notes if c.notes else ''})"
-            for c in memory.characters
-        )
-        parts.append(f"- Characters: {char_list}")
-
-    if memory.places:
-        parts.append(f"- Places: {', '.join(p.translated for p in memory.places)}")
-
-    if memory.organizations:
-        parts.append(f"- Organizations: {', '.join(o.translated for o in memory.organizations)}")
+    if has_entities:
+        parts.append("Known entities (use these translations consistently):")
+        if memory.characters:
+            char_list = ", ".join(
+                f"{c.translated_name} ({c.gender}{', ' + c.notes if c.notes else ''})"
+                for c in memory.characters
+            )
+            parts.append(f"- Characters: {char_list}")
+        if memory.places:
+            parts.append(f"- Places: {', '.join(p.translated for p in memory.places)}")
+        if memory.organizations:
+            parts.append(f"- Organizations: {', '.join(o.translated for o in memory.organizations)}")
 
     if memory.story_summary:
-        parts.append(f"\nStory so far: {memory.story_summary}")
+        if parts:
+            parts.append("")  # blank line separator
+        parts.append(f"Story so far: {memory.story_summary}")
 
     return "\n".join(parts)

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -1,6 +1,10 @@
+import os
+import tempfile
+
 import pytest
 from pydantic import ValidationError
 from data_model import CharacterEntry, EntityEntry, SessionMemory
+from memory_utils import serialize_memory, load_memory, format_memory_for_prompt
 
 
 def test_character_entry_defaults():
@@ -39,11 +43,6 @@ def test_character_entry_requires_name_and_gender():
 def test_entity_entry_requires_both_fields():
     with pytest.raises(ValidationError):
         EntityEntry(original="新宿")  # missing translated
-
-
-import os
-import tempfile
-from memory_utils import serialize_memory, load_memory, format_memory_for_prompt
 
 
 def _sample_memory() -> SessionMemory:
@@ -111,3 +110,17 @@ def test_serialize_creates_readable_markdown():
     assert "## Organizations" in content
     assert "田中" in content
     assert "Tanaka" in content
+
+
+def test_serialize_load_roundtrip_with_pipe_in_notes():
+    mem = SessionMemory(
+        characters=[CharacterEntry(original_name="田中", translated_name="Tanaka", gender="male", notes="hero | protagonist")],
+        places=[],
+        organizations=[],
+        story_summary="",
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "memory.md")
+        serialize_memory(mem, path)
+        loaded = load_memory(path)
+    assert loaded.characters[0].notes == "hero | protagonist"

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -39,3 +39,75 @@ def test_character_entry_requires_name_and_gender():
 def test_entity_entry_requires_both_fields():
     with pytest.raises(ValidationError):
         EntityEntry(original="新宿")  # missing translated
+
+
+import os
+import tempfile
+from memory_utils import serialize_memory, load_memory, format_memory_for_prompt
+
+
+def _sample_memory() -> SessionMemory:
+    return SessionMemory(
+        characters=[
+            CharacterEntry(original_name="田中", translated_name="Tanaka", gender="male", notes="protagonist"),
+            CharacterEntry(original_name="桜", translated_name="Sakura", gender="female"),
+        ],
+        places=[EntityEntry(original="新宿", translated="Shinjuku")],
+        organizations=[EntityEntry(original="黒烏", translated="Black Crow Corp")],
+        story_summary="Tanaka discovers a hidden door.",
+    )
+
+
+def test_serialize_load_roundtrip():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "memory.md")
+        mem = _sample_memory()
+        serialize_memory(mem, path)
+        loaded = load_memory(path)
+
+    assert loaded.story_summary == "Tanaka discovers a hidden door."
+    assert len(loaded.characters) == 2
+    assert loaded.characters[0].original_name == "田中"
+    assert loaded.characters[0].translated_name == "Tanaka"
+    assert loaded.characters[0].gender == "male"
+    assert loaded.characters[0].notes == "protagonist"
+    assert loaded.characters[1].gender == "female"
+    assert len(loaded.places) == 1
+    assert loaded.places[0].original == "新宿"
+    assert loaded.places[0].translated == "Shinjuku"
+    assert len(loaded.organizations) == 1
+    assert loaded.organizations[0].translated == "Black Crow Corp"
+
+
+def test_load_memory_missing_file():
+    loaded = load_memory("/tmp/does_not_exist_xyz.md")
+    assert loaded == SessionMemory()
+
+
+def test_format_memory_for_prompt_empty():
+    result = format_memory_for_prompt(SessionMemory())
+    assert result == ""
+
+
+def test_format_memory_for_prompt_populated():
+    mem = _sample_memory()
+    result = format_memory_for_prompt(mem)
+    assert "Tanaka (male" in result
+    assert "Sakura (female" in result
+    assert "Shinjuku" in result
+    assert "Black Crow Corp" in result
+    assert "Tanaka discovers a hidden door." in result
+
+
+def test_serialize_creates_readable_markdown():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "memory.md")
+        serialize_memory(_sample_memory(), path)
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+    assert "## Story Summary" in content
+    assert "## Characters" in content
+    assert "## Places" in content
+    assert "## Organizations" in content
+    assert "田中" in content
+    assert "Tanaka" in content

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -1,0 +1,30 @@
+import pytest
+from data_model import CharacterEntry, EntityEntry, SessionMemory
+
+
+def test_character_entry_defaults():
+    entry = CharacterEntry(original_name="田中", translated_name="Tanaka", gender="male")
+    assert entry.notes == ""
+
+
+def test_entity_entry():
+    entry = EntityEntry(original="新宿", translated="Shinjuku")
+    assert entry.original == "新宿"
+    assert entry.translated == "Shinjuku"
+
+
+def test_session_memory_defaults():
+    mem = SessionMemory()
+    assert mem.characters == []
+    assert mem.places == []
+    assert mem.organizations == []
+    assert mem.story_summary == ""
+
+
+def test_session_memory_json_schema_has_required_fields():
+    schema = SessionMemory.model_json_schema()
+    props = schema.get("properties", {})
+    assert "characters" in props
+    assert "places" in props
+    assert "organizations" in props
+    assert "story_summary" in props

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 from data_model import CharacterEntry, EntityEntry, SessionMemory
 
 
@@ -28,3 +29,13 @@ def test_session_memory_json_schema_has_required_fields():
     assert "places" in props
     assert "organizations" in props
     assert "story_summary" in props
+
+
+def test_character_entry_requires_name_and_gender():
+    with pytest.raises(ValidationError):
+        CharacterEntry(original_name="田中")  # missing translated_name and gender
+
+
+def test_entity_entry_requires_both_fields():
+    with pytest.raises(ValidationError):
+        EntityEntry(original="新宿")  # missing translated

--- a/tests/test_text_utils_memory.py
+++ b/tests/test_text_utils_memory.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+from data_model import CharacterEntry, EntityEntry, SessionMemory
+from text_utils import update_session_memory
+import tempfile, os
+
+
+def _make_translations():
+    return [
+        {"original": "田中はどこだ？", "translated": "Where is Tanaka?"},
+        {"original": "新宿に行った。", "translated": "He went to Shinjuku."},
+    ]
+
+
+def test_update_session_memory_returns_session_memory():
+    updated = SessionMemory(
+        characters=[CharacterEntry(original_name="田中", translated_name="Tanaka", gender="male")],
+        places=[EntityEntry(original="新宿", translated="Shinjuku")],
+        organizations=[],
+        story_summary="Tanaka went to Shinjuku.",
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("text_utils.call_llm", return_value=updated.model_dump_json()):
+            result = update_session_memory(_make_translations(), SessionMemory(), "test-model", tmpdir)
+
+    assert isinstance(result, SessionMemory)
+    assert result.characters[0].translated_name == "Tanaka"
+    assert result.story_summary == "Tanaka went to Shinjuku."
+
+
+def test_update_session_memory_writes_memory_md():
+    updated = SessionMemory(
+        characters=[CharacterEntry(original_name="田中", translated_name="Tanaka", gender="male")],
+        places=[],
+        organizations=[],
+        story_summary="Tanaka went to Shinjuku.",
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("text_utils.call_llm", return_value=updated.model_dump_json()):
+            update_session_memory(_make_translations(), SessionMemory(), "test-model", tmpdir)
+        assert os.path.exists(os.path.join(tmpdir, "memory.md"))
+
+
+def test_update_session_memory_falls_back_on_invalid_json():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("text_utils.call_llm", return_value="NOT VALID JSON"):
+            original = SessionMemory(story_summary="original summary")
+            result = update_session_memory(_make_translations(), original, "test-model", tmpdir)
+    assert result.story_summary == "original summary"

--- a/tests/test_text_utils_memory.py
+++ b/tests/test_text_utils_memory.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 from data_model import CharacterEntry, EntityEntry, SessionMemory
-from text_utils import update_session_memory
+from text_utils import update_session_memory, get_formatted_user_prompt, get_formatted_user_prompt_with_image
 import tempfile, os
 
 
@@ -55,8 +55,6 @@ def test_update_session_memory_falls_back_on_schema_violating_json():
             result = update_session_memory(_make_translations(), original, "test-model", tmpdir)
     assert result.story_summary == "original summary"
 
-
-from text_utils import get_formatted_user_prompt, get_formatted_user_prompt_with_image
 
 
 def _sample_memory() -> SessionMemory:

--- a/tests/test_text_utils_memory.py
+++ b/tests/test_text_utils_memory.py
@@ -54,3 +54,78 @@ def test_update_session_memory_falls_back_on_schema_violating_json():
             original = SessionMemory(story_summary="original summary")
             result = update_session_memory(_make_translations(), original, "test-model", tmpdir)
     assert result.story_summary == "original summary"
+
+
+from text_utils import get_formatted_user_prompt, get_formatted_user_prompt_with_image
+
+
+def _sample_memory() -> SessionMemory:
+    return SessionMemory(
+        characters=[CharacterEntry(original_name="田中", translated_name="Tanaka", gender="male", notes="protagonist")],
+        places=[EntityEntry(original="新宿", translated="Shinjuku")],
+        organizations=[EntityEntry(original="黒烏", translated="Black Crow Corp")],
+        story_summary="Tanaka arrived in Shinjuku.",
+    )
+
+
+def test_prompt_includes_memory_section():
+    prompt = get_formatted_user_prompt(
+        context="page context",
+        text="田中はどこだ？",
+        source_language="Japanese",
+        target_language="English",
+        session_memory=_sample_memory(),
+    )
+    assert "Tanaka (male" in prompt
+    assert "Shinjuku" in prompt
+    assert "Black Crow Corp" in prompt
+    assert "Tanaka arrived in Shinjuku." in prompt
+
+
+def test_prompt_excludes_memory_section_when_empty():
+    prompt = get_formatted_user_prompt(
+        context="page context",
+        text="田中はどこだ？",
+        source_language="Japanese",
+        target_language="English",
+        session_memory=SessionMemory(),
+    )
+    assert "Known entities" not in prompt
+    assert "Story so far" not in prompt
+
+
+def test_prompt_excludes_memory_section_when_none():
+    prompt = get_formatted_user_prompt(
+        context="page context",
+        text="田中はどこだ？",
+        source_language="Japanese",
+        target_language="English",
+    )
+    assert "Known entities" not in prompt
+
+
+def test_prompt_with_image_includes_memory_section():
+    prompt = get_formatted_user_prompt_with_image(
+        context="page context",
+        text="田中はどこだ？",
+        source_language="Japanese",
+        target_language="English",
+        session_memory=_sample_memory(),
+    )
+    assert "Tanaka (male" in prompt
+    assert "Tanaka arrived in Shinjuku." in prompt
+
+
+def test_memory_injected_before_previous_translations():
+    prev = [{"original": "こんにちは", "translated": "Hello"}]
+    prompt = get_formatted_user_prompt(
+        context="ctx",
+        text="田中はどこだ？",
+        source_language="Japanese",
+        target_language="English",
+        previous_translations=prev,
+        session_memory=_sample_memory(),
+    )
+    memory_pos = prompt.index("Known entities")
+    prev_pos = prompt.index("Previous translations")
+    assert memory_pos < prev_pos

--- a/tests/test_text_utils_memory.py
+++ b/tests/test_text_utils_memory.py
@@ -129,3 +129,31 @@ def test_memory_injected_before_previous_translations():
     memory_pos = prompt.index("Known entities")
     prev_pos = prompt.index("Previous translations")
     assert memory_pos < prev_pos
+
+
+def test_memory_injected_before_previous_translations_with_image():
+    prev = [{"original": "こんにちは", "translated": "Hello"}]
+    prompt = get_formatted_user_prompt_with_image(
+        context="ctx",
+        text="田中はどこだ？",
+        source_language="Japanese",
+        target_language="English",
+        previous_translations=prev,
+        session_memory=_sample_memory(),
+    )
+    memory_pos = prompt.index("Known entities")
+    prev_pos = prompt.index("Previous translations")
+    assert memory_pos < prev_pos
+
+
+def test_prompt_includes_summary_when_only_summary_set():
+    mem = SessionMemory(story_summary="Tanaka arrived in Shinjuku.")
+    prompt = get_formatted_user_prompt(
+        context="ctx",
+        text="田中はどこだ？",
+        source_language="Japanese",
+        target_language="English",
+        session_memory=mem,
+    )
+    assert "Story so far: Tanaka arrived in Shinjuku." in prompt
+    assert "Known entities" not in prompt

--- a/tests/test_text_utils_memory.py
+++ b/tests/test_text_utils_memory.py
@@ -46,3 +46,11 @@ def test_update_session_memory_falls_back_on_invalid_json():
             original = SessionMemory(story_summary="original summary")
             result = update_session_memory(_make_translations(), original, "test-model", tmpdir)
     assert result.story_summary == "original summary"
+
+
+def test_update_session_memory_falls_back_on_schema_violating_json():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("text_utils.call_llm", return_value='{"characters": null}'):
+            original = SessionMemory(story_summary="original summary")
+            result = update_session_memory(_make_translations(), original, "test-model", tmpdir)
+    assert result.story_summary == "original summary"

--- a/text_utils.py
+++ b/text_utils.py
@@ -65,7 +65,12 @@ def contains_japanese(text: str) -> bool:
 
 
 def get_formatted_user_prompt(
-    context: str, text: str, source_language: str, target_language: str, previous_translations: list = None
+    context: str,
+    text: str,
+    source_language: str,
+    target_language: str,
+    previous_translations: list = None,
+    session_memory: SessionMemory = None,
 ) -> str:
     prompt = f"""Translate this {source_language} text from the manga to {target_language}.
 
@@ -74,6 +79,10 @@ Context: <context>{context}</context>
 Text to translate: <text>{text}</text>
 
 """
+
+    memory_section = format_memory_for_prompt(session_memory) if session_memory else ""
+    if memory_section:
+        prompt += memory_section + "\n\n"
 
     if previous_translations:
         prompt += "Previous translations on this page (for consistency):\n"
@@ -92,7 +101,12 @@ Text to translate: <text>{text}</text>
 
 
 def get_formatted_user_prompt_with_image(
-    context: str, text: str, source_language: str, target_language: str, previous_translations: list = None
+    context: str,
+    text: str,
+    source_language: str,
+    target_language: str,
+    previous_translations: list = None,
+    session_memory: SessionMemory = None,
 ) -> str:
     prompt = f"""Translate this {source_language} text from the manga to {target_language}.
 
@@ -101,6 +115,10 @@ Context: <context>{context}</context>
 Text to translate: <text>{text}</text>
 
 """
+
+    memory_section = format_memory_for_prompt(session_memory) if session_memory else ""
+    if memory_section:
+        prompt += memory_section + "\n\n"
 
     if previous_translations:
         prompt += "Previous translations on this page (for consistency):\n"
@@ -206,6 +224,7 @@ def translate(
     target_language: str = "English",
     image: Image.Image = None,
     previous_translations: list = None,
+    session_memory: SessionMemory = None,
 ) -> str:
     # Normalize non-Japanese text early
     if not contains_japanese(text):
@@ -218,11 +237,13 @@ def translate(
     if image is not None:
         print("Using image for translation...")
         user_prompt = get_formatted_user_prompt_with_image(
-            context, text, source_language, target_language, previous_translations
+            context, text, source_language, target_language,
+            previous_translations, session_memory=session_memory,
         )
     else:
         user_prompt = get_formatted_user_prompt(
-            context, text, source_language, target_language, previous_translations
+            context, text, source_language, target_language,
+            previous_translations, session_memory=session_memory,
         )
 
     response = call_llm(

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,24 +1,51 @@
+import os
 import re
 import jaconv
 import unicodedata
+from PIL import Image
 from ollama import chat, ChatResponse
-from data_model import Translation
+from data_model import Translation, SessionMemory
+from memory_utils import serialize_memory, format_memory_for_prompt
 
 # Fixed System Prompt
 SYSTEM_PROMPT = """
-You are an experienced manga translator for one of the biggest publishers in the world. 
-You will be given the entire context of a page or chapter and then will be asked to translate a specific text which is part of that context. 
-You must use the context to provide an accurate translation of the text. 
-Do not translate the context in one go. Ensure that the translated text remains meaningful taking the overall context into account.
-Ensure the tenses and pronoun are consistent across the translation.
+You are an experienced manga translator for one of the biggest publishers in the world.
+You will be given the context of surrounding pages and then asked to translate a specific text from the current page.
+
+ATMOSPHERE & TONE (most important):
+- Read the context carefully to infer the genre, mood, and setting (e.g. tense action, lighthearted comedy, emotional romance, horror, slice-of-life).
+- Match your word choices and sentence rhythm to that inferred atmosphere. A battle cry should feel urgent and punchy. Casual banter should feel relaxed and colloquial. Heartfelt dialogue should feel warm and natural.
+- Infer each character's speech register from context (formal, rough, childlike, archaic, etc.) and reflect it consistently.
+- Prioritise natural, genre-appropriate dialogue over word-for-word literal accuracy. The translation should sound like something a real person would say in that genre — not a textbook sentence.
+
+CONSISTENCY:
+- Ensure tenses and pronouns are consistent across the translation.
+- If previous translations are provided, use them as reference for terminology, character voice, and style.
 
 CRITICAL OUTPUT RULES:
-- Output ONLY the translated text, nothing else
 - DO NOT include explanations, breakdown, notes, or commentary about the translation
-- The onomatopoeia needs to be translated according to how it sounds
-- Similarly translate, voices for suprises like for example え？ being "Eh?" or "Huh"?
-- The translated text is going to replace the original text, hence the length of the translation SHOULD be close the number of characters inside <text> tags
+- Translate onomatopoeia according to how it sounds in the target language
+- Translate surprise/reaction sounds naturally (e.g. え？ → "Huh?" or "Eh?", depending on the scene's tone)
+- The translated text will replace the original, so its length SHOULD be close to the number of characters inside <text> tags
 """.strip()
+
+def clean_ocr_garbage(text: str) -> str:
+    if not text.strip():
+        return text
+
+    # Remove long chains of identical box-drawing / line chars
+    text = re.sub(r'([┌┐└┘├┤┬┴┼─│━┃═║]{3,})', '', text)          # ≥3 repeated line chars
+
+    # Remove chains of almost any non-letter/symbol punctuation junk
+    text = re.sub(r'([^\w\s\u3000-\u30FF\u4E00-\u9FFF]{3,})', '', text)
+
+    # Optional: collapse multiple punctuation → single (…… → …)
+    text = re.sub(r'([…ー〜\-=]{2,})', lambda m: m.group(1)[0]*min(3, len(m.group(1))), text)
+
+    # Remove trailing/leading junk that often appears
+    text = text.strip(' .,…ー〜└│─═║┌┐┘├┤\u200b\ufeff')  # zero-width & invisible too
+
+    return text.strip()
 
 
 def is_japanese_char(char: str) -> bool:
@@ -37,19 +64,58 @@ def contains_japanese(text: str) -> bool:
 
 
 def get_formatted_user_prompt(
-    context: str, text: str, source_language: str, target_language: str
+    context: str, text: str, source_language: str, target_language: str, previous_translations: list = None
 ) -> str:
-    return f"""Translate this {source_language} text from the manga to {target_language}.
+    prompt = f"""Translate this {source_language} text from the manga to {target_language}.
 
 Context: <context>{context}</context>
 
 Text to translate: <text>{text}</text>
 
+"""
+
+    if previous_translations:
+        prompt += "Previous translations on this page (for consistency):\n"
+        for i, prev in enumerate(previous_translations, 1):
+            prompt += f"{i}. {source_language}: {prev['original']}\n   {target_language}: {prev['translated']}\n"
+        prompt += "\n"
+
+    prompt += f"""Match the tone and atmosphere of the surrounding context in your translation.
+
 - You are to return JSON structure output with two fields
-    - text - the original text that was supposed to be translated which would be {text}
-    - translated_texts - a list of possible translations for the input text in {target_language}.
-    - notes - any notes about the translation in less than 20 words
+    - text - the original text that was supposed to be translated. The value of this field should be {text}.
+    - translated_text - the translation for the input text in {target_language}.
 """.strip()
+
+    return prompt
+
+
+def get_formatted_user_prompt_with_image(
+    context: str, text: str, source_language: str, target_language: str, previous_translations: list = None
+) -> str:
+    prompt = f"""Translate this {source_language} text from the manga to {target_language}.
+
+Context: <context>{context}</context>
+
+Text to translate: <text>{text}</text>
+
+"""
+
+    if previous_translations:
+        prompt += "Previous translations on this page (for consistency):\n"
+        for i, prev in enumerate(previous_translations, 1):
+            prompt += f"{i}. {source_language}: {prev['original']}\n   {target_language}: {prev['translated']}\n"
+        prompt += "\n"
+
+    prompt += f"""Match the tone and atmosphere of the surrounding context in your translation.
+
+- You are to return JSON structure output with two fields
+    - text - the original text that was supposed to be translated which would be {text}. SHOULD NOT BE EMPTY
+    - translated_text - the translation for the input text in {target_language}.
+- Use the provided image to aid your translation
+""".strip()
+
+    return prompt
 
 
 def clean_translated_text(text: str) -> str:
@@ -64,7 +130,7 @@ def clean_translated_text(text: str) -> str:
 
 
 def post_process(text: str) -> str:
-    """Post-process Japanese text: normalize spaprint(translation.translated_texts)cing, ellipses, and half-width chars."""
+    """Post-process Japanese text: normalize spacing, ellipses, and half-width chars."""
     text = "".join(text.split())
     text = text.replace("…", "...")
     text = re.sub(r"[・.]{2,}", lambda m: "." * len(m.group()), text)
@@ -76,21 +142,37 @@ def call_llm(
     model: str,
     system_prompt: str,
     user_prompt: str,
-    temperature: float = 0.0,
+    temperature: float = 0.35,
     num_ctx: int = 256,
     frequency_penalty: float = 0.5,
-    presence_penalty: float = 0.2,
+    presence_penalty: float = 1.5                            ,
     stop: list = None,
     format: str = None,
+    image: Image.Image = None,
 ) -> str:
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+    ]
+    
+    if image is not None:
+        # Convert PIL Image to bytes for ollama
+        import io
+        image_bytes = io.BytesIO()
+        image.save(image_bytes, format="PNG")
+        
+        messages.append({
+            "role": "user",
+            "content": user_prompt,
+            "images": [image_bytes.getvalue()],
+        })
+    else:
+        messages.append({"role": "user", "content": user_prompt})
 
     response: ChatResponse = chat(
         model=model,
         format=format,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
+        messages=messages,
         options={
             "temperature": temperature,
             "num_ctx": num_ctx,
@@ -98,9 +180,19 @@ def call_llm(
             "frequency_penalty": frequency_penalty,
             "presence_penalty": presence_penalty,
             "stop": stop,
+            "think": False, 
         },
         stream=False,
     )
+
+    print("========================================= LLM Thinking ================================================================")
+    print(response.message.thinking)
+    print("========================================================================================================================")
+
+
+    print("========================================= LLM Response ================================================================")
+    print(response.message.content)
+    print("========================================================================================================================")
 
     return response.message.content
 
@@ -111,21 +203,33 @@ def translate(
     context: str,
     source_language: str,
     target_language: str = "English",
+    image: Image.Image = None,
+    previous_translations: list = None,
 ) -> str:
     # Normalize non-Japanese text early
     if not contains_japanese(text):
         return unicodedata.normalize("NFKC", text)
 
+    text = clean_ocr_garbage(text)
+    text = post_process(text)
+
     # Main translation call
-    user_prompt = get_formatted_user_prompt(
-        context, text, source_language, target_language
-    )
+    if image is not None:
+        print("Using image for translation...")
+        user_prompt = get_formatted_user_prompt_with_image(
+            context, text, source_language, target_language, previous_translations
+        )
+    else:
+        user_prompt = get_formatted_user_prompt(
+            context, text, source_language, target_language, previous_translations
+        )
+
     response = call_llm(
-        model, SYSTEM_PROMPT, user_prompt, format=Translation.model_json_schema()
+        model, SYSTEM_PROMPT, user_prompt, format=Translation.model_json_schema(), image=image
     )
     translation = Translation.model_validate_json(response)
 
-    cleaned_text = translation.translated_texts[0]
+    cleaned_text = translation.translated_text
     cleaned_text = clean_translated_text(cleaned_text)
 
     # Debug prints (optional — comment out in production)
@@ -139,18 +243,76 @@ def translate(
         or contains_japanese(cleaned_text)
     ):
         cleaned_text = fallback_translation(
-            text, model, source_language, target_language
+            text, model, source_language, target_language, image
         )
 
     return cleaned_text
 
 
 def fallback_translation(
-    text: str, model: str, source_language: str, target_language: str
+    text: str, model: str, source_language: str, target_language: str, image: Image.Image = None
 ) -> str:
     """Fallback: act as Google Translate for direct Japanese → target translation."""
     system_prompt = f"Your role is to act as DeepL translate. Translate the given a text in{source_language} to {target_language}. Output ONLY the translation."
     user_prompt = f"Translate to {target_language}: {text}"
 
-    fallback_translation = call_llm(model, system_prompt, user_prompt)
+    fallback_translation = call_llm(model, system_prompt, user_prompt, num_ctx=4096, image=image)
     return clean_translated_text(fallback_translation)
+
+
+MEMORY_UPDATE_SYSTEM_PROMPT = """
+You are a manga translation assistant responsible for maintaining a translation memory.
+Given the current page's translations and the existing memory state, you must:
+1. Identify new named entities: characters (with gender inferred from speech/context/names), places, organizations
+2. Update existing entries only if a correction is clearly warranted
+3. Rewrite the story summary to include events from this page (150 words max, cumulative)
+
+Output ONLY valid JSON matching the provided schema. No commentary or explanation.
+""".strip()
+
+
+def update_session_memory(
+    translations: list[dict],
+    session_memory: SessionMemory,
+    model: str,
+    temp_dir: str,
+) -> SessionMemory:
+    current_chars = [
+        f"{c.original_name} → {c.translated_name} ({c.gender})" +
+        (f", {c.notes}" if c.notes else "")
+        for c in session_memory.characters
+    ]
+    current_places = [f"{p.original} → {p.translated}" for p in session_memory.places]
+    current_orgs = [f"{o.original} → {o.translated}" for o in session_memory.organizations]
+
+    page_text = "\n".join(
+        f"Original: {t['original']}\nTranslated: {t['translated']}"
+        for t in translations
+    )
+
+    user_prompt = f"""Current memory state:
+Characters: {', '.join(current_chars) if current_chars else 'none'}
+Places: {', '.join(current_places) if current_places else 'none'}
+Organizations: {', '.join(current_orgs) if current_orgs else 'none'}
+Story summary: {session_memory.story_summary or 'none'}
+
+Current page translations:
+{page_text}
+
+Return the complete updated memory as JSON."""
+
+    response = call_llm(
+        model,
+        MEMORY_UPDATE_SYSTEM_PROMPT,
+        user_prompt,
+        format=SessionMemory.model_json_schema(),
+        num_ctx=4096,
+    )
+
+    try:
+        updated = SessionMemory.model_validate_json(response)
+    except Exception:
+        updated = session_memory
+
+    serialize_memory(updated, os.path.join(temp_dir, "memory.md"))
+    return updated

--- a/text_utils.py
+++ b/text_utils.py
@@ -153,7 +153,7 @@ def call_llm(
     model: str,
     system_prompt: str,
     user_prompt: str,
-    temperature: float = 0.35,
+    temperature: float = 0.25,
     num_ctx: int = 256,
     frequency_penalty: float = 0.5,
     presence_penalty: float = 1.5,
@@ -195,15 +195,6 @@ def call_llm(
         },
         stream=False,
     )
-
-    print("========================================= LLM Thinking ================================================================")
-    print(response.message.thinking)
-    print("========================================================================================================================")
-
-
-    print("========================================= LLM Response ================================================================")
-    print(response.message.content)
-    print("========================================================================================================================")
 
     return response.message.content
 

--- a/text_utils.py
+++ b/text_utils.py
@@ -4,6 +4,7 @@ import jaconv
 import unicodedata
 from PIL import Image
 from ollama import chat, ChatResponse
+from pydantic import ValidationError
 from data_model import Translation, SessionMemory
 from memory_utils import serialize_memory, format_memory_for_prompt
 
@@ -264,7 +265,7 @@ MEMORY_UPDATE_SYSTEM_PROMPT = """
 You are a manga translation assistant responsible for maintaining a translation memory.
 Given the current page's translations and the existing memory state, you must:
 1. Identify new named entities: characters (with gender inferred from speech/context/names), places, organizations
-2. Update existing entries only if a correction is clearly warranted
+2. Preserve ALL entries from the existing memory — never drop an entity just because it does not appear in the current page. Only update an entry if a clear correction is warranted.
 3. Rewrite the story summary to include events from this page (150 words max, cumulative)
 
 Output ONLY valid JSON matching the provided schema. No commentary or explanation.
@@ -290,6 +291,12 @@ def update_session_memory(
         for t in translations
     )
 
+    schema_hint = (
+        '{"characters":[{"original_name":"...","translated_name":"...","gender":"male|female|unknown","notes":"..."}],'
+        '"places":[{"original":"...","translated":"..."}],'
+        '"organizations":[{"original":"...","translated":"..."}],'
+        '"story_summary":"..."}'
+    )
     user_prompt = f"""Current memory state:
 Characters: {', '.join(current_chars) if current_chars else 'none'}
 Places: {', '.join(current_places) if current_places else 'none'}
@@ -299,6 +306,7 @@ Story summary: {session_memory.story_summary or 'none'}
 Current page translations:
 {page_text}
 
+Expected JSON shape: {schema_hint}
 Return the complete updated memory as JSON."""
 
     response = call_llm(
@@ -311,7 +319,7 @@ Return the complete updated memory as JSON."""
 
     try:
         updated = SessionMemory.model_validate_json(response)
-    except Exception:
+    except (ValueError, ValidationError):
         updated = session_memory
 
     serialize_memory(updated, os.path.join(temp_dir, "memory.md"))

--- a/text_utils.py
+++ b/text_utils.py
@@ -64,6 +64,30 @@ def contains_japanese(text: str) -> bool:
     return any(is_japanese_char(char) for char in text)
 
 
+def _build_prompt_base(
+    context: str,
+    text: str,
+    source_language: str,
+    target_language: str,
+    previous_translations: list,
+    session_memory: "SessionMemory | None",
+) -> str:
+    prompt = (
+        f"Translate this {source_language} text from the manga to {target_language}.\n\n"
+        f"Context: <context>{context}</context>\n\n"
+        f"Text to translate: <text>{text}</text>\n\n"
+    )
+    memory_section = format_memory_for_prompt(session_memory) if session_memory else ""
+    if memory_section:
+        prompt += memory_section + "\n\n"
+    if previous_translations:
+        prompt += "Previous translations on this page (for consistency):\n"
+        for i, prev in enumerate(previous_translations, 1):
+            prompt += f"{i}. {source_language}: {prev['original']}\n   {target_language}: {prev['translated']}\n"
+        prompt += "\n"
+    return prompt
+
+
 def get_formatted_user_prompt(
     context: str,
     text: str,
@@ -72,31 +96,15 @@ def get_formatted_user_prompt(
     previous_translations: list = None,
     session_memory: SessionMemory = None,
 ) -> str:
-    prompt = f"""Translate this {source_language} text from the manga to {target_language}.
-
-Context: <context>{context}</context>
-
-Text to translate: <text>{text}</text>
-
-"""
-
-    memory_section = format_memory_for_prompt(session_memory) if session_memory else ""
-    if memory_section:
-        prompt += memory_section + "\n\n"
-
-    if previous_translations:
-        prompt += "Previous translations on this page (for consistency):\n"
-        for i, prev in enumerate(previous_translations, 1):
-            prompt += f"{i}. {source_language}: {prev['original']}\n   {target_language}: {prev['translated']}\n"
-        prompt += "\n"
-
+    prompt = _build_prompt_base(
+        context, text, source_language, target_language,
+        previous_translations, session_memory,
+    )
     prompt += f"""Match the tone and atmosphere of the surrounding context in your translation.
 
 - You are to return JSON structure output with two fields
     - text - the original text that was supposed to be translated. The value of this field should be {text}.
-    - translated_text - the translation for the input text in {target_language}.
-""".strip()
-
+    - translated_text - the translation for the input text in {target_language}."""
     return prompt
 
 
@@ -108,32 +116,16 @@ def get_formatted_user_prompt_with_image(
     previous_translations: list = None,
     session_memory: SessionMemory = None,
 ) -> str:
-    prompt = f"""Translate this {source_language} text from the manga to {target_language}.
-
-Context: <context>{context}</context>
-
-Text to translate: <text>{text}</text>
-
-"""
-
-    memory_section = format_memory_for_prompt(session_memory) if session_memory else ""
-    if memory_section:
-        prompt += memory_section + "\n\n"
-
-    if previous_translations:
-        prompt += "Previous translations on this page (for consistency):\n"
-        for i, prev in enumerate(previous_translations, 1):
-            prompt += f"{i}. {source_language}: {prev['original']}\n   {target_language}: {prev['translated']}\n"
-        prompt += "\n"
-
+    prompt = _build_prompt_base(
+        context, text, source_language, target_language,
+        previous_translations, session_memory,
+    )
     prompt += f"""Match the tone and atmosphere of the surrounding context in your translation.
 
 - You are to return JSON structure output with two fields
     - text - the original text that was supposed to be translated which would be {text}. SHOULD NOT BE EMPTY
     - translated_text - the translation for the input text in {target_language}.
-- Use the provided image to aid your translation
-""".strip()
-
+- Use the provided image to aid your translation"""
     return prompt
 
 
@@ -164,7 +156,7 @@ def call_llm(
     temperature: float = 0.35,
     num_ctx: int = 256,
     frequency_penalty: float = 0.5,
-    presence_penalty: float = 1.5                            ,
+    presence_penalty: float = 1.5,
     stop: list = None,
     format: str = None,
     image: Image.Image = None,

--- a/text_utils.py
+++ b/text_utils.py
@@ -239,7 +239,7 @@ def translate(
         )
 
     response = call_llm(
-        model, SYSTEM_PROMPT, user_prompt, format=Translation.model_json_schema(), image=image
+        model, SYSTEM_PROMPT, user_prompt, format=Translation.model_json_schema(), num_ctx=2048, image=image
     )
     translation = Translation.model_validate_json(response)
 
@@ -291,6 +291,9 @@ def update_session_memory(
     model: str,
     temp_dir: str,
 ) -> SessionMemory:
+    if not translations:
+        return session_memory
+
     current_chars = [
         f"{c.original_name} → {c.translated_name} ({c.gender})" +
         (f", {c.notes}" if c.notes else "")
@@ -332,7 +335,8 @@ Return the complete updated memory as JSON."""
 
     try:
         updated = SessionMemory.model_validate_json(response)
-    except (ValueError, ValidationError):
+    except (ValueError, ValidationError) as e:
+        print(f"[memory] WARNING: Failed to parse LLM memory update response: {e}. Keeping existing memory.")
         updated = session_memory
 
     serialize_memory(updated, os.path.join(temp_dir, "memory.md"))


### PR DESCRIPTION
## Summary
- Adds a session-scoped memory module that tracks named entities (characters with gender, places, organizations) and a rolling story summary across all pages in a translation run
- After each page is translated, a dedicated LLM call extracts new entities and updates the story summary, serialized to `{temp_dir}/memory.md` for human inspection and resume support
- Session memory is injected into every translation prompt alongside the existing page context, ensuring consistent entity names and correct pronoun usage throughout the run

## Test Plan
- [ ] Run `pytest tests/` — 23 tests covering serialization roundtrip, prompt injection, fallback behavior, and edge cases
- [ ] Smoke test: `python -c "from inference import driver; print('OK')"`
- [ ] End-to-end: run a translation with `--temp-dir` and verify `memory.md` is created and populated after the first page
- [ ] Verify resume: interrupt a run and re-run — the existing `memory.md` should be loaded and memory continues from where it left off

🤖 Generated with [Claude Code](https://claude.com/claude-code)